### PR TITLE
ImportError: cannot import name parse

### DIFF
--- a/ufile/filemanager.py
+++ b/ufile/filemanager.py
@@ -13,8 +13,10 @@ from .compact import b, s, u, url_parse
 from . import config
 from .config import BLOCKSIZE
 import string
-from urllib import parse
-
+try:
+    from urllib.parse import urlparse
+except ImportError:
+     from urlparse import urlparse
 
 class FileManager(BaseUFile):
     """


### PR DESCRIPTION
centos7环境报错：


Traceback (most recent call last):
  File "./xxxx.py", line 25, in <module>
    from ufile import filemanager
  File "/usr/lib/python2.7/site-packages/ufile/filemanager.py", line 16, in <module>
    from urllib import parse
ImportError: cannot import name parse